### PR TITLE
Implement Python FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+frontend/node_modules
+backend/node_modules
+*.log
+.env
+/uploads
+venv
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# App
+# PrintShop QR Uploader
+
+Proof of concept for uploading print jobs via a unique QR code.
+
+## Features
+- Unique QR per shop linking to `/upload/:shopSlug`.
+- JWT-based auth with `user`, `shopOwner`, `admin` roles.
+- Upload images/docs (150 MB limit) to local `/uploads` or S3.
+- E-mail notification and basic Socket.IO hooks.
+- Simple React + Tailwind interface.
+
+## Setup
+### Backend (FastAPI)
+```bash
+cd backend
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # edit values
+uvicorn app.main:app --reload
+```
+
+### Frontend
+```bash
+cd frontend
+npm install
+cp .env.example .env
+npm run dev
+```
+
+### Sample cURL
+```bash
+# signup
+curl -X POST http://localhost:8000/api/auth/signup \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"a@b.com","password":"pass"}'
+
+# login
+curl -X POST http://localhost:8000/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"a@b.com","password":"pass"}'
+```
+
+### Postman
+Import `postman_collection.json` into Postman.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,11 @@
+MONGODB_URI=mongodb://localhost:27017/printshop
+JWT_SECRET=supersecret
+JWT_EXPIRES_IN=3600
+ALLOWED_ORIGINS=http://localhost:5173
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USER=user@example.com
+EMAIL_PASS=password
+USE_S3=false
+S3_BUCKET=your-bucket
+S3_REGION=us-east-1

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel, EmailStr
+from passlib.context import CryptContext
+from datetime import datetime, timedelta
+import jwt
+import os
+
+from .main import db
+from .models import UserModel, PyObjectId
+
+router = APIRouter()
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+class SignupBody(BaseModel):
+    email: EmailStr
+    password: str
+
+class LoginBody(SignupBody):
+    pass
+
+def create_token(data: dict):
+    expire = datetime.utcnow() + timedelta(seconds=int(os.getenv("JWT_EXPIRES_IN", "3600")))
+    to_encode = {**data, "exp": expire}
+    return jwt.encode(to_encode, os.getenv("JWT_SECRET"), algorithm="HS256")
+
+async def get_user(email: str):
+    return await db.users.find_one({"email": email})
+
+@router.post("/signup")
+async def signup(body: SignupBody):
+    if await get_user(body.email):
+        raise HTTPException(status_code=400, detail="Email exists")
+    hashed = pwd_context.hash(body.password)
+    user = UserModel(email=body.email, password=hashed)
+    res = await db.users.insert_one(user.dict(by_alias=True))
+    user.id = res.inserted_id
+    token = create_token({"id": str(user.id), "role": user.role})
+    return {"token": token, "user": user}
+
+@router.post("/login")
+async def login(body: LoginBody):
+    user = await get_user(body.email)
+    if not user or not pwd_context.verify(body.password, user["password"]):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_token({"id": str(user["_id"]), "role": user.get("role", "user")})
+    return {"token": token, "user": UserModel(**user)}
+
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+security = HTTPBearer()
+
+def auth_required(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    try:
+        payload = jwt.decode(credentials.credentials, os.getenv("JWT_SECRET"), algorithms=["HS256"])
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return payload

--- a/backend/app/dashboard.py
+++ b/backend/app/dashboard.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends, HTTPException
+from bson import ObjectId
+from .auth import auth_required
+from .main import db
+from .models import UploadModel
+
+router = APIRouter()
+
+@router.get('/')
+async def pending(user=Depends(auth_required)):
+    if user.get('role') != 'shopOwner':
+        raise HTTPException(status_code=403, detail='Forbidden')
+    uploads = []
+    cursor = db.uploads.find({'shop': ObjectId(user.get('shop')), 'printed': False})
+    async for doc in cursor:
+        uploads.append(UploadModel(**doc))
+    return {'uploads': uploads}
+
+@router.patch('/{uid}/printed')
+async def mark_printed(uid: str, user=Depends(auth_required)):
+    if user.get('role') != 'shopOwner':
+        raise HTTPException(status_code=403, detail='Forbidden')
+    await db.uploads.update_one({'_id': ObjectId(uid)}, {'$set': {'printed': True}})
+    return {'status': 'ok'}
+
+@router.delete('/{uid}')
+async def delete_upload(uid: str, user=Depends(auth_required)):
+    if user.get('role') != 'shopOwner':
+        raise HTTPException(status_code=403, detail='Forbidden')
+    await db.uploads.delete_one({'_id': ObjectId(uid)})
+    return {'status': 'ok'}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from motor.motor_asyncio import AsyncIOMotorClient
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=os.getenv("ALLOWED_ORIGINS", "*").split(","),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+client = AsyncIOMotorClient(os.getenv("MONGODB_URI"))
+db = client.get_default_database()
+
+from .auth import router as auth_router
+from .shops import router as shops_router
+from .uploads import router as upload_router
+from .dashboard import router as dashboard_router
+
+app.include_router(auth_router, prefix="/api/auth")
+app.include_router(shops_router, prefix="/api/shops")
+app.include_router(upload_router, prefix="/api/upload")
+app.include_router(dashboard_router, prefix="/api/dashboard")
+

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,46 @@
+from pydantic import BaseModel, EmailStr, Field
+from typing import List, Optional
+from bson import ObjectId
+
+class PyObjectId(ObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if isinstance(v, ObjectId):
+            return v
+        return ObjectId(str(v))
+
+class UserModel(BaseModel):
+    id: PyObjectId | None = Field(alias="_id", default=None)
+    email: EmailStr
+    password: str
+    role: str = "user"
+    shop: Optional[PyObjectId] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
+
+class ShopModel(BaseModel):
+    id: PyObjectId | None = Field(alias="_id", default=None)
+    name: str
+    slug: str
+    owner: PyObjectId
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
+
+class UploadModel(BaseModel):
+    id: PyObjectId | None = Field(alias="_id", default=None)
+    shop: PyObjectId
+    user: PyObjectId
+    files: List[str]
+    printed: bool = False
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}

--- a/backend/app/shops.py
+++ b/backend/app/shops.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+from .auth import auth_required
+from .main import db
+from .models import ShopModel, UserModel
+from .utils.qrcode import generate_qr
+from bson import ObjectId
+import re
+
+router = APIRouter()
+
+class ShopBody(BaseModel):
+    name: str
+    slug: str
+    owner_id: str
+
+@router.post('/')
+async def create_shop(body: ShopBody, user=Depends(auth_required)):
+    if user.get('role') != 'admin':
+        raise HTTPException(status_code=403, detail='Forbidden')
+    slug = re.sub(r'[^a-z0-9-]', '', body.slug.lower())
+    shop = ShopModel(name=body.name, slug=slug, owner=ObjectId(body.owner_id))
+    res = await db.shops.insert_one(shop.dict(by_alias=True))
+    shop.id = res.inserted_id
+    await db.users.update_one({'_id': ObjectId(body.owner_id)}, {'$set': {'role': 'shopOwner', 'shop': shop.id}})
+    qr = generate_qr(slug)
+    return {'shop': shop, 'qr': qr}
+
+@router.get('/{slug}/qr')
+async def qr(slug: str):
+    shop = await db.shops.find_one({'slug': slug})
+    if not shop:
+        raise HTTPException(status_code=404, detail='Not found')
+    return {'qr': generate_qr(slug)}

--- a/backend/app/uploads.py
+++ b/backend/app/uploads.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
+from typing import List
+from bson import ObjectId
+import os
+import boto3
+
+from .auth import auth_required
+from .main import db
+from .models import UploadModel
+from .utils.email import send_upload_email
+
+router = APIRouter()
+
+UPLOAD_DIR = 'uploads'
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+@router.post('/{slug}')
+async def upload_files(slug: str, files: List[UploadFile] = File(...), user=Depends(auth_required)):
+    shop = await db.shops.find_one({'slug': slug})
+    if not shop:
+        raise HTTPException(status_code=404, detail='Shop not found')
+
+    paths = []
+    for f in files:
+        if os.getenv('USE_S3') == 'true':
+            s3 = boto3.client('s3', region_name=os.getenv('S3_REGION'))
+            key = f"{ObjectId()}-{f.filename}"
+            s3.upload_fileobj(f.file, os.getenv('S3_BUCKET'), key)
+            url = f"https://{os.getenv('S3_BUCKET')}.s3.amazonaws.com/{key}"
+            paths.append(url)
+        else:
+            path = os.path.join(UPLOAD_DIR, f"{ObjectId()}-{f.filename}")
+            with open(path, 'wb') as out:
+                out.write(await f.read())
+            paths.append(path)
+
+    upload = UploadModel(shop=shop['_id'], user=ObjectId(user['id']), files=paths)
+    res = await db.uploads.insert_one(upload.dict(by_alias=True))
+    upload.id = res.inserted_id
+
+    await send_upload_email(shop['owner'], paths)
+    # socket.io notifications could be added here
+    return {'upload': upload}

--- a/backend/app/utils/email.py
+++ b/backend/app/utils/email.py
@@ -1,0 +1,20 @@
+import os
+import smtplib
+from email.message import EmailMessage
+
+async def send_upload_email(owner_id: str, files: list[str]):
+    host = os.getenv('EMAIL_HOST')
+    if not host:
+        return
+    msg = EmailMessage()
+    msg['Subject'] = 'New Print Upload'
+    msg['From'] = os.getenv('EMAIL_USER')
+    msg['To'] = owner_id
+    msg.set_content('Files uploaded:\n' + '\n'.join(files))
+    try:
+        with smtplib.SMTP(host, int(os.getenv('EMAIL_PORT', '25'))) as s:
+            s.starttls()
+            s.login(os.getenv('EMAIL_USER'), os.getenv('EMAIL_PASS'))
+            s.send_message(msg)
+    except Exception as exc:
+        print('email error', exc)

--- a/backend/app/utils/qrcode.py
+++ b/backend/app/utils/qrcode.py
@@ -1,0 +1,14 @@
+import qrcode
+import base64
+from io import BytesIO
+
+BASE_URL = 'https://printshop.example.com/upload/'
+
+def generate_qr(slug: str) -> str:
+    qr = qrcode.QRCode(box_size=3, border=2)
+    qr.add_data(BASE_URL + slug)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    return base64.b64encode(buf.getvalue()).decode()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+motor
+python-multipart
+passlib[bcrypt]
+PyJWT
+boto3
+python-dotenv
+qrcode

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000/api

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "browser": true,
+    "es2022": true
+  },
+  "extends": ["airbnb"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {
+    "react/react-in-jsx-scope": "off",
+    "import/no-extraneous-dependencies": "off",
+    "react/jsx-filename-extension": [1, { "extensions": [".jsx"] }]
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PrintShop QR Uploader</title>
+  <link rel="stylesheet" href="/src/index.css" />
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "printshop-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.1",
+    "socket.io-client": "^4.6.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.46.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-react": "^7.33.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.14",
+    "vite": "^4.3.9"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './pages/App.jsx';
+import './index.css';
+import { AuthProvider } from './utils/auth.jsx';
+
+createRoot(document.getElementById('root')).render(
+  <BrowserRouter>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </BrowserRouter>,
+);

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -1,0 +1,27 @@
+import { Routes, Route, Link, Navigate } from 'react-router-dom';
+import Login from './Login.jsx';
+import Signup from './Signup.jsx';
+import Upload from './Upload.jsx';
+import Dashboard from './Dashboard.jsx';
+import { useAuth } from '../utils/auth.jsx';
+
+export default function App() {
+  const { token, logout } = useAuth();
+  return (
+    <div className="container mx-auto p-4">
+      <nav className="flex justify-between mb-4">
+        <Link to="/">Home</Link>
+        {token && (
+          <button type="button" onClick={logout} className="text-blue-500">Logout</button>
+        )}
+      </nav>
+      <Routes>
+        <Route path="/" element={<Navigate to="/login" />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route path="/upload/:slug" element={<Upload />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { useApi } from '../utils/api.js';
+import { useAuth } from '../utils/auth.jsx';
+import { io } from 'socket.io-client';
+
+export default function Dashboard() {
+  const [uploads, setUploads] = useState([]);
+  const api = useApi();
+  const { user, token } = useAuth();
+
+  const fetchUploads = async () => {
+    const { data } = await api.get('/dashboard');
+    setUploads(data.uploads);
+  };
+
+  useEffect(() => {
+    if (!token) return;
+    fetchUploads();
+    const socket = io(import.meta.env.VITE_API_URL.replace('/api', ''), { query: { userId: user.id } });
+    socket.on('new-upload', fetchUploads);
+    return () => socket.disconnect();
+  }, [token]);
+
+  if (!token) return <p className="text-center">Login first</p>;
+
+  return (
+    <div>
+      <h1 className="text-xl mb-2">Dashboard</h1>
+      <table className="min-w-full bg-white">
+        <thead>
+          <tr><th className="p-2">User</th><th className="p-2">Files</th><th className="p-2">Actions</th></tr>
+        </thead>
+        <tbody>
+          {uploads.map((u) => (
+            <tr key={u._id} className="border-t">
+              <td className="p-2">{u.user.email}</td>
+              <td className="p-2">
+                {u.files.map((f) => <a href={`/${f}`} key={f} className="block text-blue-500" target="_blank" rel="noopener noreferrer">{f}</a>)}
+              </td>
+              <td className="p-2">
+                <button type="button" onClick={() => api.patch(`/dashboard/${u._id}/printed`).then(fetchUploads)} className="text-green-600 mr-2">Printed</button>
+                <button type="button" onClick={() => api.delete(`/dashboard/${u._id}`).then(fetchUploads)} className="text-red-600">Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../utils/auth.jsx';
+import { useApi } from '../utils/api.js';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { setToken, setUser } = useAuth();
+  const api = useApi();
+  const navigate = useNavigate();
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const { data } = await api.post('/auth/login', { email, password });
+    setToken(data.token);
+    setUser(data.user);
+    navigate('/dashboard');
+  };
+
+  return (
+    <form onSubmit={submit} className="max-w-sm mx-auto bg-white p-4 shadow">
+      <h1 className="text-xl mb-2">Login</h1>
+      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" className="border p-2 w-full mb-2" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" className="border p-2 w-full mb-2" />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">Login</button>
+      <p className="mt-2 text-center text-sm">
+        <Link to="/signup" className="text-blue-500">Sign up</Link>
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../utils/auth.jsx';
+import { useApi } from '../utils/api.js';
+
+export default function Signup() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { setToken, setUser } = useAuth();
+  const api = useApi();
+  const navigate = useNavigate();
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const { data } = await api.post('/auth/signup', { email, password });
+    setToken(data.token);
+    setUser(data.user);
+    navigate('/dashboard');
+  };
+
+  return (
+    <form onSubmit={submit} className="max-w-sm mx-auto bg-white p-4 shadow">
+      <h1 className="text-xl mb-2">Sign Up</h1>
+      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" className="border p-2 w-full mb-2" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" className="border p-2 w-full mb-2" />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">Sign Up</button>
+      <p className="mt-2 text-center text-sm">
+        <Link to="/login" className="text-blue-500">Login</Link>
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useApi } from '../utils/api.js';
+
+export default function Upload() {
+  const { slug } = useParams();
+  const [files, setFiles] = useState([]);
+  const api = useApi();
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const formData = new FormData();
+    files.forEach((f) => formData.append('files', f));
+    await api.post(`/upload/${slug}`, formData);
+    alert('Uploaded!');
+  };
+
+  return (
+    <form onSubmit={submit} className="max-w-md mx-auto bg-white p-4 shadow">
+      <h1 className="text-xl mb-2">Upload Files</h1>
+      <input type="file" multiple onChange={(e) => setFiles(Array.from(e.target.files))} className="mb-2" />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">Upload</button>
+    </form>
+  );
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { useAuth } from './auth.jsx';
+
+const instance = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+});
+
+export const useApi = () => {
+  const { token } = useAuth();
+  instance.defaults.headers.Authorization = token ? `Bearer ${token}` : '';
+  return instance;
+};
+
+export default instance;

--- a/frontend/src/utils/auth.jsx
+++ b/frontend/src/utils/auth.jsx
@@ -1,0 +1,23 @@
+import { useState, useEffect, createContext, useContext } from 'react';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    if (token) localStorage.setItem('token', token);
+    else localStorage.removeItem('token');
+  }, [token]);
+
+  const logout = () => setToken(null);
+
+  return (
+    <AuthContext.Provider value={{ token, setToken, user, setUser, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1,0 +1,26 @@
+{
+  "info": {
+    "name": "PrintShop API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Signup",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "url": {"raw": "{{url}}/api/auth/signup"},
+        "body": {"mode": "raw", "raw": "{\n  \"email\": \"a@b.com\",\n  \"password\": \"pass\"\n}"}
+      }
+    },
+    {
+      "name": "Login",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "url": {"raw": "{{url}}/api/auth/login"},
+        "body": {"mode": "raw", "raw": "{\n  \"email\": \"a@b.com\",\n  \"password\": \"pass\"\n}"}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace Node backend with FastAPI implementation
- add Mongo models and auth, shop, upload, dashboard routes
- update env examples and README for Python backend
- set frontend API default to port 8000

## Testing
- `python -m py_compile backend/app/**/*.py`
- `npm run build` *(fails: vite not found)*